### PR TITLE
policy_add(): define credentials as empty list.

### DIFF
--- a/nessrest/ness6rest.py
+++ b/nessrest/ness6rest.py
@@ -214,7 +214,7 @@ class Scanner(object):
         self.ver_plugins = self.res['loaded_plugin_set']
 
 ################################################################################
-    def policy_add(self, name, plugins, credentials, template="advanced"):
+    def policy_add(self, name, plugins, credentials=[], template="advanced"):
         '''
         Add a policy and store the returned ID. The template defaults to
         "advanced" to remain compatible with the calls that occur in Nessus


### PR DESCRIPTION
The example policy_add() usage does not mention credentials which
results in the following problem:
TypeError: policy_add() takes at least 4 arguments (3 given)