### PR TITLE
Verify ca bundle

### DIFF
--- a/nessrest/nessus-scan
+++ b/nessrest/nessus-scan
@@ -17,10 +17,11 @@ parser.add_argument('--target',  required=True)
 parser.add_argument('--policy', required=True)
 parser.add_argument('--name', required=True)
 parser.add_argument('--insecure', action="store_true")
+parser.add_argument('--ca_bundle')
 args = parser.parse_args()
 
 # Log in
-scan = ness6rest.Scanner(url=nessus_url, login=login, password=password, insecure=args.insecure)
+scan = ness6rest.Scanner(url=nessus_url, login=login, password=password, insecure=args.insecure, ca_bundle=args.ca_bundle)
 
 # Set policy that should be used
 scan.policy_set(name=args.policy)


### PR DESCRIPTION
I ran into SSL problems, which could be solved by supplying a CA bundle. Seems like a nice feature to have if running with --insecure is not an option.

I also changed the error message for SSL problems to contain the actual error message. While they can be hard to understand, I still feel this gives the user a better chance of solving the problem.

I added the functionality to nessus-scanner for reference.