### PR TITLE
Allow retry of commands following timeout of auth

### DIFF
--- a/nessrest/ness6rest.py
+++ b/nessrest/ness6rest.py
@@ -101,7 +101,6 @@ class Scanner(object):
 
 ################################################################################
     def _login(self, login="", password=""):
-        seperator = '_:_'
         if login and password:
             self.auth = [login,password]
 


### PR DESCRIPTION
Method to re-authenticate if a scan runs too long and times out.

I did put some effort in to obfuscating credentials in memory, but figured the credentials are already in memory with object __init__, and maybe even environment.  If important by the team, I could put more effort into it.  Generally, scripts using the nessrest should be relatively short lived.