### PR TITLE
Decode json when text has been returned.

### DIFF
--- a/nessrest/ness6rest.py
+++ b/nessrest/ness6rest.py
@@ -165,7 +165,7 @@ class Scanner(object):
             req = requests.request(method, url, data=payload, files=files,
                                    verify=verify, headers=headers)
 
-            if not download:
+            if not download and req.text:
                 self.res = req.json()
 
             if req.status_code != 200:


### PR DESCRIPTION
When testing 6.3, destroy was throwing a ValueError on reg.json() when there was no text returned.  Added this check to make sure there is information to decode.