### PR TITLE
Fixing obvious errors in Scan.__init__ and PostgreSQL.__init__

### DIFF
--- a/nessrest/credentials.py
+++ b/nessrest/credentials.py
@@ -213,7 +213,7 @@ class PostgreSQL(Database):
     Username and password for Database PostgreSQL
     '''
     def __init__(self, username, password, port=5432):
-        super(PostgresSQL, self).__init__(username, password, port, "PostgresSQL")
+        super(PostgreSQL, self).__init__(username, password, port, "PostgreSQL")
 
 
 class SQLServer(Database):

--- a/nessrest/ness6scan.py
+++ b/nessrest/ness6scan.py
@@ -45,7 +45,7 @@ class Scan(object):
         self._cache = {}
 
         if template:
-            set_scan_template(template)
+            self.set_scan_template(template)
 
         if self.scanner.scan_exists(name):
             self.get_scan_settings(self.scanner.scan_id)


### PR DESCRIPTION
Fixing two obvious errors:

* ```Scan.__init__``` tries to call an unbound set_scan_template function instead of the bound method with the same name
* ```PostgreSQL.__init__``` has a mistype in the super call (PostgresSQL instead of PostgreSQL), as well as in the ```type``` param in super call