### PR TITLE
added pending status check to _scan_status()

### DIFF
--- a/nessrest/ness6rest.py
+++ b/nessrest/ness6rest.py
@@ -704,7 +704,7 @@ class Scanner(object):
 
             for scan in self.res["scans"]:
                 if (scan["uuid"] == self.scan_uuid
-                        and scan['status'] == "running"):
+                        and (scan['status'] == "running" or scan['status'] == "pending")):
 
                     sys.stdout.write(".")
                     sys.stdout.flush()
@@ -715,7 +715,7 @@ class Scanner(object):
                         print("")
 
                 if (scan["uuid"] == self.scan_uuid
-                        and scan['status'] != "running"):
+                        and scan['status'] != "running" and scan['status'] != "pending"):
 
                     running = False
 


### PR DESCRIPTION
We are using nessrest to interface with Nessus Cloud (not sure if that is where this issue comes from) and when starting new scans, they start out with a status "pending" and therefore are immediately assumed to be completed. I added "pending" status checks so that the wait loop stays open during pending AND running status.