### PR TITLE
proper to check the key, not that there is just a response

### DIFF
--- a/nessrest/ness6rest.py
+++ b/nessrest/ness6rest.py
@@ -497,7 +497,7 @@ class Scanner(object):
         for plugin in plugins.split(','):
             self.action(action="plugins/plugin/" + str(plugin), method="GET")
 
-            if self.res:
+            if "attributes" in self.res:
                 for attrib in self.res["attributes"]:
                     if attrib["attribute_name"] == "fname":
                         self.plugins.update({str(plugin):


### PR DESCRIPTION
We still get a response when there are no corresponding plugins present. Old code throws a KeyError