### PR TITLE
Added policy_limit_ports method

### DIFF
--- a/nessrest/ness6rest.py
+++ b/nessrest/ness6rest.py
@@ -376,6 +376,15 @@ class Scanner(object):
         self.action(action="policies/" + str(self.policy_id), method="put",
                     extra=extra)
 
+###############################################################################
+    def policy_limit_ports(self, ports):
+        '''
+        Limit the ports scanned to the given list.
+        '''
+        extra = {"settings": {"portscan_range": str(ports)}}
+        self.action(action="policies/" + str(self.policy_id), method="put",
+            extra=extra)
+
 ################################################################################
     def policy_add_creds(self, credentials, policy_id=""):
         '''


### PR DESCRIPTION
Added policy_limit_ports method to scanner.

This allows a user to modify the current policy so that it only scans the given list of ports.