### PR TITLE
Re-write of download all script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 ness_rest.conf
 __pycache__
 MANIFEST
+.project
+.pydevproject

--- a/scripts/nessus_api_eg.key.json
+++ b/scripts/nessus_api_eg.key.json
@@ -1,0 +1,4 @@
+{
+  "accessKey": "BASE64STRING",
+  "secretKey": "BASE64STRING"
+}

--- a/scripts/nessus_download_all.py
+++ b/scripts/nessus_download_all.py
@@ -81,8 +81,12 @@ if scanner:
   scans = scanner.res['scans']
   # create scan subfolders
   for f in folders:
-    if not os.path.exists(f['name']) and not (f['type'] == 'trash' and args.trash):
-      os.mkdir(f['name'])
+    if not os.path.exists(f['name']):
+      if f['type'] == 'trash':
+        if args.trash:
+          os.mkdir(f['name'])
+      else:
+        os.mkdir(f['name'])
   # try download and save scans into each folder the belong to
   for s in scans:
     scanner.scan_name = s['name']

--- a/scripts/nessus_download_all.py
+++ b/scripts/nessus_download_all.py
@@ -20,7 +20,7 @@ def print_err(str_error, fatal=False):
 parser = argparse.ArgumentParser(description='Download completed nessus scans.')
 parser.add_argument('-s', '--server', help='IP address of Nessus API endpoint', default='127.0.0.1')
 parser.add_argument('-p', '--port', help='port number of Nessus API endpoint', type=int, default=8834)
-parser.add_argument('-f', '--format', help='report format', choices=['nessus', 'pdf', 'html', 'csv'], default='nessus')
+parser.add_argument('-f', '--format', help='report format', choices=['nessus', 'html', 'csv'], default='nessus')
 parser.add_argument('-c', '--capath', help='certificate authority path', default=None)
 parser.add_argument('-t', '--trash', help='include trash folder', action='store_true', default=False)
 parser.add_argument('--insecure', help='boldly go forth and ignore cert errors', action='store_true', default=False)
@@ -98,12 +98,12 @@ if scanner:
       file_name = file_name.replace('/','_')
       file_name = file_name.strip()
       relative_path_name = folder_name + '/' + file_name
-      if args.format == 'pdf':
-        fp = io.open(relative_path_name,'wb')
-      else:
-        fp = io.open(relative_path_name,'w')
-      fp.write(scanner.download_scan(export_format=args.format))
-      fp.close()
+      # PDF not yet supported
+      # python API wrapper nessrest returns the PDF as a string object instead of a byte object, making writing and correctly encoding the file a chore...
+      # other formats can be written out in text mode
+      with io.open(relative_path_name,'wt') as fp:
+        fp.write(scanner.download_scan(export_format=args.format))
+
 else:
   print_err('Failed to use scanner at ' + nessus_url + '.', True)
 

--- a/scripts/nessus_download_all.py
+++ b/scripts/nessus_download_all.py
@@ -1,19 +1,109 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
+
 import sys
+import os
+import io
+import argparse
+import getpass
+import json
+
 sys.path.append('../')
 from nessrest import ness6rest
+  
+# Print error function
+def print_err(str_error, fatal=False):
+  sys.stderr.write('ERROR: ' + str_error + '\n')
+  if fatal:
+    exit('Exiting due to fatal error.')
 
-import getpass
-user = getpass._raw_input('User: ')
-password = getpass.getpass()
+# Parse command line options
+parser = argparse.ArgumentParser(description='Download completed nessus scans.')
+parser.add_argument('-s', '--server', help='IP address of Nessus API endpoint', default='127.0.0.1')
+parser.add_argument('-p', '--port', help='port number of Nessus API endpoint', type=int, default=8834)
+parser.add_argument('-f', '--format', help='report format', choices=['nessus', 'pdf', 'html', 'csv'], default='nessus')
+parser.add_argument('-c', '--capath', help='certificate authority path', default=None)
+parser.add_argument('-t', '--trash', help='include trash folder', action='store_true', default=False)
+parser.add_argument('--insecure', help='boldly go forth and ignore cert errors', action='store_true', default=False)
+group = parser.add_mutually_exclusive_group()
+group.add_argument('-k', '--keyfile', help='API key file in json format')
+group.add_argument('-u', '--user', help='Nessus user instead of API key (password prompt will occur)')
+args = parser.parse_args()
 
-scan = ness6rest.Scanner(url="https://127.0.0.1:8834",login=user,password=password, insecure=True)
-scan.action(action="scans", method="get")
-for s in scan.res['scans']:
-  scan.scan_name = s['name']
-  scan.scan_id = s['id']
-  xml_nessus = scan.download_scan(export_format='nessus')
-  fp = open('%s_%s.nessus'%(scan.scan_name,scan.scan_id),"w")
-  fp.write(xml_nessus)
-  fp.close()
+# Get keys
+keys = None
+password = None
+if args.keyfile:
+  if os.path.isfile(args.keyfile):
+    try:
+      f_key = open(args.keyfile, 'r')
+      try:
+        keys = json.loads(f_key.read())
+      except ValueError as err:
+        print_err(str(err))
+        print_err('could parse read key file "' + args.keyfile + '".', True)
+      f_key.close()
+    except IOError:
+      print_err('could not read key file "' + args.keyfile + '".', True)
+  else:
+    print_err('"' + args.keyfile + '" is not a valid file.', True)
+elif args.user:
+  password = getpass.getpass()
+else:
+  parser.error('No action taken, either a key file or user must be provided')
+
+if args.capath and not os.path.isdir(args.capath):
+  print_err('CA path "' + args.capath + '" not found.', True)
+
+nessus_url = "https://" + args.server + ":" + str(args.port)
+insecure = args.insecure
+localhost = args.server == 'localhost' or args.server[:4] == '127.' or args.server == '::1'
+
+# allow localhost connections to proceed without warning, but warn otherwise if CA not set
+if not args.capath:
+  if localhost:
+    insecure = True
+  elif not insecure:
+    # warn if user hasn't supplied a CA Path, but might expect security or bump into TLS errors later
+    print('WARNING:  No CA path explicitly set. Connection to ' + nessus_url + ' could fail due to TLS/SSL server authentication')
+
+scanner = None
+if keys:
+  scanner = ness6rest.Scanner(url=nessus_url, api_akey=keys['accessKey'], api_skey=keys['secretKey'], insecure=insecure, ca_bundle=args.capath)
+elif password:
+  scanner = ness6rest.Scanner(url=nessus_url, login=args.user, password=password, insecure=insecure, ca_bundle=args.capath)
+else:
+  print_err('Failed to understand API key or password (this is probably a script BUG)', True)
+
+# Get all reports
+if scanner:
+  scanner.action(action='scans', method='get')
+  folders = scanner.res['folders']
+  scans = scanner.res['scans']
+  # create scan subfolders
+  for f in folders:
+    if not os.path.exists(f['name']) and not (f['type'] == 'trash' and args.trash):
+      os.mkdir(f['name'])
+  # try download and save scans into each folder the belong to
+  for s in scans:
+    scanner.scan_name = s['name']
+    scanner.scan_id = s['id']
+    folder_name = next(f['name'] for f in folders if f['id'] == s['folder_id'])
+    folder_type = next(f['type'] for f in folders if f['id'] == s['folder_id'])
+    # skip trash items?
+    if folder_type == 'trash' and not args.trash:
+      continue
+    if s['status'] == 'completed':
+      file_name = '%s_%s.%s' % (scanner.scan_name, scanner.scan_id, args.format)
+      file_name = file_name.replace('\\','_')
+      file_name = file_name.replace('/','_')
+      file_name = file_name.strip()
+      relative_path_name = folder_name + '/' + file_name
+      if args.format == 'pdf':
+        fp = io.open(relative_path_name,'wb')
+      else:
+        fp = io.open(relative_path_name,'w')
+      fp.write(scanner.download_scan(export_format=args.format))
+      fp.close()
+else:
+  print_err('Failed to use scanner at ' + nessus_url + '.', True)
 


### PR DESCRIPTION
Original python script, while short and simple, didn't check if scan results were complete, didn't correctly handle scans with a slash in the title, didn't support API keys and only ran in insecure mode. Replacement version (based on it) adds some extra checks and mirrors the folder structure on the nessus scanner along with additional command line argument parsing so that it can run as a cli tool instead of needing to be modified directly.

Arguably, the download functionality could be better placed in the `ness_rest` cli tool.