### PR TITLE
Fix get_host_details

### DIFF
--- a/nessrest/ness6rest.py
+++ b/nessrest/ness6rest.py
@@ -835,7 +835,7 @@ class Scanner(object):
         # Get details of requested scan
 
         self.action(action="scans/" + str(scan_id) + "/hosts/" + str(host_id), method="get")
-        if host_id not in self.host_details:
+        if scan_id not in self.host_details:
             self.host_details[scan_id] = {}
         self.host_details[scan_id][host_id]=self.res
 


### PR DESCRIPTION
Bad checking was deleting all previously found host details for the scan_id
passed as an argument. Also, it crashed when the host_id was equal to a
previously found scan_id, but the scan_id passed wasn't in host_details.