### PR TITLE
fix import of modules for ness_rest client

### DIFF
--- a/nessrest/ness_rest
+++ b/nessrest/ness_rest
@@ -29,7 +29,8 @@
 # EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from __future__ import print_function
-from nessrest import ness6rest, credentials
+import ness6rest
+import credentials
 import argparse
 import os
 import sys


### PR DESCRIPTION
fix import line to import the ness6rest and credentials module as they are used explicitly in the sample client.