### PR TITLE
Support credentials renewing

### DIFF
--- a/nessrest/ness6rest.py
+++ b/nessrest/ness6rest.py
@@ -248,7 +248,7 @@ class Scanner(object):
             raise Exception("Could not connect to %s.\nExiting!\n" % url)
 
         if self.res and "error" in self.res and retry:
-            if self.res["error"] == "You need to log in to perform this request" or self.res["error"] == "Invalid credentials":
+            if self.res["error"] == "You need to log in to perform this request" or self.res["error"] == "Invalid Credentials":
                 self._login()
                 self.action(action=action, method=method, extra=extra, files=files,
                             json_req=json_req, download=download, private=private,

--- a/nessrest/ness6rest.py
+++ b/nessrest/ness6rest.py
@@ -248,7 +248,7 @@ class Scanner(object):
             raise Exception("Could not connect to %s.\nExiting!\n" % url)
 
         if self.res and "error" in self.res and retry:
-            if self.res["error"] == "You need to log in to perform this request":
+            if self.res["error"] == "You need to log in to perform this request" or self.res["error"] == "Invalid credentials":
                 self._login()
                 self.action(action=action, method=method, extra=extra, files=files,
                             json_req=json_req, download=download, private=private,


### PR DESCRIPTION
Sometimes, while waiting for large scans to complete, the token generated by Nessus invalidates. The error message in such case is different than "You need to log in to perform this request", so I added a conditional checking for the invalidated credentials message in the place where _login() method is called.