### PR TITLE
avoid to add policy_id when it is empty

### DIFF
--- a/nessrest/ness6rest.py
+++ b/nessrest/ness6rest.py
@@ -661,7 +661,10 @@ class Scanner(object):
         # Dynamic items
         settings.update({"scanner_id": str(self.scanner_id)})
         settings.update({"name": self.scan_name})
-        settings.update({"policy_id": self.policy_id})
+
+        if self.policy_id:
+            settings.update({"policy_id": self.policy_id})
+
         settings.update({"folder_id": self.tag_id})
         settings.update({"text_targets": text_targets})
 


### PR DESCRIPTION
When trying to launch a scan the parameter "policy_id" is added to every api request, even when not provided previously, this causes the api call to fail since it is mandatory to either provide a valid one or none.

![screen shot 2017-02-05 at 14 26 03](https://cloud.githubusercontent.com/assets/6126291/22626501/138638b4-ebaf-11e6-9c69-4349ec1b279d.png)
