### PR TITLE
Optional plugins

### DIFF
--- a/nessrest/ness6rest.py
+++ b/nessrest/ness6rest.py
@@ -301,10 +301,11 @@ class Scanner(object):
         except KeyError:
             print("policy_id was not returned. Exiting")
             sys.exit(1)
-        
+
+        self.policy_add_creds(credentials=credentials)
+        self._policy_set_settings()
+
         if plugins != None:
-            self.policy_add_creds(credentials=credentials)
-            self._policy_set_settings()
             self.plugins_info(plugins=plugins)
             self._enable_plugins()
 

--- a/nessrest/ness6rest.py
+++ b/nessrest/ness6rest.py
@@ -283,7 +283,7 @@ class Scanner(object):
                 break
 
 ################################################################################
-    def policy_add(self, name, plugins, credentials=[], template="advanced"):
+    def policy_add(self, name, plugins=None, credentials=[], template="advanced"):
         '''
         Add a policy and store the returned ID. The template defaults to
         "advanced" to remain compatible with the calls that occur in Nessus
@@ -301,11 +301,12 @@ class Scanner(object):
         except KeyError:
             print("policy_id was not returned. Exiting")
             sys.exit(1)
-
-        self.policy_add_creds(credentials=credentials)
-        self._policy_set_settings()
-        self.plugins_info(plugins=plugins)
-        self._enable_plugins()
+        
+        if plugins != None:
+            self.policy_add_creds(credentials=credentials)
+            self._policy_set_settings()
+            self.plugins_info(plugins=plugins)
+            self._enable_plugins()
 
 ################################################################################
     def policy_copy(self, existing_policy_name, new_policy_name):


### PR DESCRIPTION
The policy_add function makes creates by default a policy based on the "advanced" template. For this, the plugins are optional. When no plugins are present, Nessus will create a policy with all plugins enabled, just like a normal advanced scan.
However, omitting the plugins parameter results in an error, which I fixed by making the plugins parameter optional. 